### PR TITLE
fix: add missing type export to package.json

### DIFF
--- a/packages/rollup-plugin-tsconfig-paths/package.json
+++ b/packages/rollup-plugin-tsconfig-paths/package.json
@@ -6,6 +6,7 @@
   "types": "./index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "require": "./index.js",
       "import": "./index.mjs"
     }

--- a/packages/ts-paths-resolve-plugin/package.json
+++ b/packages/ts-paths-resolve-plugin/package.json
@@ -6,6 +6,7 @@
   "types": "./index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "require": "./index.js",
       "import": "./index.mjs"
     }

--- a/packages/vite-plugin-tsconfig-paths/package.json
+++ b/packages/vite-plugin-tsconfig-paths/package.json
@@ -6,6 +6,7 @@
   "types": "./index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "require": "./index.js",
       "import": "./index.mjs"
     }


### PR DESCRIPTION
add missing type export to package.json to fix error:

>  error TS7016: Could not find a declaration file for module 'rollup-plugin-tsconfig-paths'. '/home/runner/work/xxx/node_modules/.pnpm/rollup-plugin-tsconfig-paths@1.5.0_rollup@3.22.0_typescript@5.0.4/node_modules/rollup-plugin-tsconfig-paths/index.mjs' implicitly has an 'any' type.
  There are types at '/home/runner/work/xxx/packages/xxx/node_modules/rollup-plugin-tsconfig-paths/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'rollup-plugin-tsconfig-paths' library may need to update its package.json or typings.